### PR TITLE
Update _dendrogram.py wrapper wrong dendrogram leaves method.

### DIFF
--- a/plotly/figure_factory/_dendrogram.py
+++ b/plotly/figure_factory/_dendrogram.py
@@ -139,7 +139,10 @@ class _Dendrogram(object):
         for i in range(len(yvals_flat)):
             if yvals_flat[i] == 0.0 and xvals_flat[i] not in self.zero_vals:
                 self.zero_vals.append(xvals_flat[i])
-
+        if len(self.zero_vals) > len(yvals) + 1:
+            l_border = int(min(self.zero_vals))
+            r_border = int(max(self.zero_vals))  
+            self.zero_vals = [v for v in range(l_border,r_border + 1, int((r_border-l_border) / len(yvals)))]
         self.zero_vals.sort()
 
         self.layout = self.set_figure_layout(width, height)


### PR DESCRIPTION
![demo](https://user-images.githubusercontent.com/16633223/33818708-64e39362-de81-11e7-8c73-24167786c56f.png)
At previous version of dendrogram script, it use easy way to detect a node whether a leaves. But in our daily work, we will meet situation like this graph show. It will make the branch become all 0. Including the parent branches. So it can't use this easy way.

Need to be cautious: It is not the leaves 'U-shape' is all zeros. It also have some parent branches 'U- shape' is all zeros. (zeros I mean is there yvalus)

But I don't have much time to fix it. So I just add a wrapper to fix this. I have checked scipy doc. It is a safe way to build a new tickvals. So I build it in this way.